### PR TITLE
Add MQTT command to resend autodiscovery

### DIFF
--- a/hacks/microsd/scripts/mqtt-control.sh
+++ b/hacks/microsd/scripts/mqtt-control.sh
@@ -6,8 +6,12 @@
 killall mosquitto_sub 2> /dev/null
 killall mosquitto_sub.bin 2> /dev/null
 
-/opt/media/sdc/bin/mosquitto_sub.bin -v -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/# ${MOSQUITTOOPTS} | while read -r line ; do
+/opt/media/sdc/bin/mosquitto_sub.bin -v -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/# -t "${LOCATION}/set" ${MOSQUITTOOPTS} | while read -r line ; do
   case $line in
+    "${LOCATION}/set announce")
+      /opt/media/sdc/scripts/mqtt-autodiscovery.sh
+    ;;
+    
     "${TOPIC}/set help")
       /opt/media/sdc/bin/mosquitto_pub.bin -h "$HOST" -p "$PORT" -u "$USER" -P "$PASS" -t "${TOPIC}"/help ${MOSQUITTOOPTS} -m "possible commands: configured topic + Yellow_LED/set on/off, configured topic + Blue_LED/set on/off, configured topic + set with the following commands: status, $(grep \)$ /opt/media/sdc/www/cgi-bin/action.cgi | grep -v '[=*]' | sed -e "s/ //g" | grep -v -E '(osd|setldr|settz|showlog)' | sed -e "s/)//g")"
     ;;


### PR DESCRIPTION
Taken from here: https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/pull/1051

In some cases (e.g., power failure), it is possible for the camera to
boot before the MQTT server is running. In this case, the autodiscovery
message will be lost.

To address this, this commit adds a topic called $LOCATION/set which
accepts an argument of 'announce'. This will trigger resending of the
autodiscovery message. It does not use the standard path of
$LOCATION/$DEVICE_NAME, because it is intended for all Xiaomi-Dafang-Hacks
cameras.

To use this, once your MQTT server is up, publish a message to
$LOCATION/set with the payload 'announce'. In Home Assistant, this can be done
with the following automation:

- id: '0000'
    alias: Dafang Announce on startup
    trigger:
    - event: start
      platform: homeassistant
    action:
      service: mqtt.publish
      data:
        payload: announce
        topic: myhome/set